### PR TITLE
Hotfix/corrige redirecionamento tela devolucao

### DIFF
--- a/src/frontend/src/components/PageHeader.jsx
+++ b/src/frontend/src/components/PageHeader.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import "../styles/PageHeader.css";
 import lupa from "../assets/icones/lupa.svg";
 import seta from "../assets/icones/seta-voltar.svg";
@@ -7,13 +7,17 @@ import seta from "../assets/icones/seta-voltar.svg";
 export default function PageHeader({ title, isSingleFita = false }) {
     const [query, setQuery] = useState("");
     const navigate = useNavigate();
+    const location = useLocation();
 
     const handleChange = (event) => {
         setQuery(event.target.value);
     };
 
     const handleBack = () => {
-        navigate("/tela-medicamentos");
+        const pathSegments = location.pathname.split('/');
+        const parentPath = pathSegments.slice(0, pathSegments.length - 1).join('/');
+        
+        navigate(parentPath);
     };
 
     return (

--- a/src/frontend/src/components/Table.jsx
+++ b/src/frontend/src/components/Table.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import "../styles/Table.css";
 import seta from "../assets/icones/seta.svg";
 
@@ -20,6 +20,7 @@ const dataPopUp = {
 
 export default function Table({ title, data, maxItems = data.length, route, onItemClick }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const visibleItems = data.slice(0, maxItems);
   const [selectedItems, setSelectedItems] = useState(Array(visibleItems.length).fill(false));
   const [selectAll, setSelectAll] = useState(false);
@@ -56,11 +57,14 @@ export default function Table({ title, data, maxItems = data.length, route, onIt
 
   const buttonText = title === "A fazer" ? "Colocar em produção" :
     title === "Possíveis devoluções" ? "Devolver" : "";
+
   const handleItemClick = (item) => {
     if (onItemClick) {
       onItemClick(dataPopUp);
     }
   };
+
+  const isCurrentRoute = location.pathname === route;
 
   return (
     <div className={`table ${showButton ? "with-button" : ""}`}>
@@ -70,7 +74,7 @@ export default function Table({ title, data, maxItems = data.length, route, onIt
             <button className="table-title-button" onClick={handleTitleClick}>
               {title}
             </button>
-            <img src={seta} alt="seta para a direita" />
+            {!isCurrentRoute && <img src={seta} alt="seta para a direita" />}
           </div>
           {title === "A fazer" && (
               <label className="select-all">


### PR DESCRIPTION
## Descrição
<!-- Explique brevemente as alterações realizadas e o motivo delas. -->
esse pr arruma para quando for telas de fitas sozinhas, como por exemplo a fazer, em progresso, prontas, possiveis devoluções e devolvidas a seta de redirecionamento do header encaminhe para a rota mãe, e que se a rota em que estamos for a mesma a rota de redirecionamento da tabela não aparece a seta para direita da tabela

## Como testar?
<!-- Explique como podemos testar as alterações, incluindo passos para reproduzir e verificar as mudanças. -->
vá para src/frontend, rode npm i, rode npm start, entre nas telas:  a fazer, em progresso, prontas, possiveis devoluções e devolvidas, e verifique se não aparece a seta para a direita na tabela, enquanto na pagina fita medicamentos e devoluções aparece, e se quando apertar na seta azul dessas paginas volte para a pagina adequada, devoluções para possiveis devoluções e devolvidas e fita medicamentos para as outras

## Tipo de alteração
<!-- Marque com um X as opções que se aplicam -->
- [x] Correção de bug
- [ ] Nova funcionalidade
- [ ] Atualização de documentação
- [ ] Refatoração de código
- [ ] Novo componente
- [ ] Nova tela
- [ ] Estilização de componente/página
- [ ] Outro (escrever)

## Checklist
<!-- Marque com um x quando o item estiver concluído -->
- [ ] Realizei testes locais e estão funcionando conforme o esperado.
- [ ] ***Este pull request está direcionado para a branch correta?***

