### PR TITLE
feat: adiciona o pop up da devolucao

### DIFF
--- a/src/frontend/src/components/PopUpDevolucao.jsx
+++ b/src/frontend/src/components/PopUpDevolucao.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import "../styles/PopUpFitas.css";
+
+export default function PopUpDevolucao({ data, closePopUp }) {
+    const [estadoDevolucao, setEstadoDevolucao] = useState(1);
+    const [fitaData, setFitaData] = useState(null);
+    const [medicamentosDevolvidos, setMedicamentosDevolvidos] = useState([]);
+
+    if (!data) return null;
+
+    const biparFita = () => {
+        setFitaData({
+            paciente: "João da Silva",
+            leito: "Leito 07",
+            ultimaAtualizacao: "26/02/2025 - 18:34",
+            aprovadoPor: "Maria Souza – 25/02/2025 - 08:15"
+        });
+        setEstadoDevolucao(2);
+    };
+
+    const biparMedicamento = () => {
+        if (estadoDevolucao === 2) {
+            setMedicamentosDevolvidos([{ nome: "Paracetamol 500mg", tipo: "Comprimido", validade: "12/2026", quantidade: 1 }]);
+            setEstadoDevolucao(3);
+        } else if (estadoDevolucao === 3) {
+            setMedicamentosDevolvidos(prev => [
+                ...prev,
+                { nome: "Amoxicilina 500mg", tipo: "Cápsula", validade: "08/2025", quantidade: 1 }
+            ]);
+            setEstadoDevolucao(4);
+        } else if (estadoDevolucao === 4) {
+            const atualizados = medicamentosDevolvidos.map(med => {
+                if (med.nome === "Amoxicilina 500mg") {
+                    return { ...med, quantidade: 2 };
+                }
+                return med;
+            });
+            setMedicamentosDevolvidos(atualizados);
+            setEstadoDevolucao(5);
+        }
+    };
+
+    const renderMensagemTopo = () => {
+        return estadoDevolucao === 1
+            ? "FAÇA A BIPAGEM DO QR CODE DA FITA"
+            : "FAÇA A BIPAGEM DO QR CODE DOS MEDICAMENTOS";
+    };
+
+    const terminarDevolucao = () => {
+        console.log("Devolução concluída"); // trocar por modal de sucesso
+        closePopUp();
+    };
+
+
+    return (
+        <div className="popup-container">
+            <div className="popup-content">
+                <div className='popup-header'>
+                    <div className='popup-header-content'>
+                        <h1 className='popup-title'>{data.nome}</h1>
+                        <span className="popup-status-tag">Fazer devolução</span>
+                    </div>
+                    <strong>{renderMensagemTopo()}</strong>
+                    <button className="close-btn" onClick={closePopUp}>&times;</button>
+                </div>
+
+                <div className="popup-body">
+                    <div className="patient-info">
+                        <div><h2>Paciente</h2><p>{fitaData?.paciente || ""}</p></div>
+                        <div><h2>Leito</h2><p>{fitaData?.leito || ""}</p></div>
+                        <div><h2>Última atualização</h2><p>{fitaData?.ultimaAtualizacao || ""}</p></div>
+                        <div><h2>Aprovada por</h2><p>{fitaData?.aprovadoPor || ""}</p></div>
+                    </div>
+
+                    <div className="medicamentos-container">
+                        <div className="medicamentos-header">
+                            <h2>Medicamentos da fita</h2>
+                        </div>
+                        <div className="medicamentos-lista">
+                            {medicamentosDevolvidos.length === 0 ? (
+                                <p className="sem-medicamentos">Nenhum medicamento devolvido.</p>
+                            ) : (
+                                medicamentosDevolvidos.map((med, index) => (
+                                    <div key={index} className="medicamento-item">
+                                        <div className="medicamento-item-content">
+                                            <div className="medicamento-info">
+                                                <h3>{med.nome}</h3>
+                                                <p>{med.tipo}</p>
+                                                <p className='validade'>Válido até {med.validade}</p>
+                                            </div>
+                                            <div className="medicamento-status">
+                                                <span className="status-badge em-estoque">Devolvida</span>
+                                                <p>{med.quantidade}x</p>
+                                            </div>
+                                        </div>
+                                        {index !== medicamentosDevolvidos.length - 1 && <hr />}
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                    </div>
+                </div>
+
+                <div style={{ display: "flex", gap: "10px", width: "100%", alignItems: 'center', justifyContent: "flex-end" }}>
+                    {estadoDevolucao === 1 && <button className="exportar-btn" onClick={biparFita}>Simular Bipagem da Fita</button>}
+                    {estadoDevolucao >= 2 && estadoDevolucao < 5 && (
+                        <button className="exportar-btn" onClick={biparMedicamento}>Simular Bipagem de Medicamento</button>
+                    )}
+                    {estadoDevolucao >= 3 && (
+                        <button
+                            className="exportar-btn"
+                            style={{ backgroundColor: "#5CE1E6", color: "#000" }}
+                            onClick={terminarDevolucao}
+                        >
+                            Terminar Devolução
+                        </button>
+                    )}
+
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/frontend/src/components/Table.jsx
+++ b/src/frontend/src/components/Table.jsx
@@ -11,14 +11,14 @@ const dataPopUp = {
   ultimaAtualizacao: '26/02/2025 - 18:34',
   aprovadoPor: 'Maria Souza - 25/02/2025 - 08:15',
   medicamentos: [
-      { nome: 'Paracetamol 500mg', tipo: 'Comprimido', validade: '12/2026', status: 'Em estoque', quantidade: 1 },
-      { nome: 'Amoxicilina 500mg', tipo: 'Cápsula', validade: '08/2025', status: 'Em falta', quantidade: 2 },
-      { nome: 'Enoxaparina 40mg', tipo: 'Seringa', validade: '08/2025', status: 'Em estoque', quantidade: 1 },
-      { nome: 'Enoxaparina 40mg', tipo: 'Seringa', validade: '08/2025', status: 'Em estoque', quantidade: 1 }
+    { nome: 'Paracetamol 500mg', tipo: 'Comprimido', validade: '12/2026', status: 'Em estoque', quantidade: 1 },
+    { nome: 'Amoxicilina 500mg', tipo: 'Cápsula', validade: '08/2025', status: 'Em falta', quantidade: 2 },
+    { nome: 'Enoxaparina 40mg', tipo: 'Seringa', validade: '08/2025', status: 'Em estoque', quantidade: 1 },
+    { nome: 'Enoxaparina 40mg', tipo: 'Seringa', validade: '08/2025', status: 'Em estoque', quantidade: 1 }
   ]
 };
 
-export default function Table({ title, data, maxItems = data.length, route, onItemClick }) {
+export default function Table({ title, data, maxItems = data.length, route, onItemClick, onButtonClick }) {
   const navigate = useNavigate();
   const visibleItems = data.slice(0, maxItems);
   const [selectedItems, setSelectedItems] = useState(Array(visibleItems.length).fill(false));
@@ -54,13 +54,24 @@ export default function Table({ title, data, maxItems = data.length, route, onIt
     navigate(route);
   };
 
-  const buttonText = title === "A fazer" ? "Colocar em produção" :
-    title === "Possíveis devoluções" ? "Devolver" : "";
   const handleItemClick = (item) => {
     if (onItemClick) {
       onItemClick(dataPopUp);
     }
   };
+
+  const handleButtonClick = () => {
+    if (onButtonClick) {
+      const selectedIndex = selectedItems.findIndex(item => item);
+      if (selectedIndex !== -1) {
+        onButtonClick(data[selectedIndex]);
+      }
+    }
+  };
+
+  const buttonText = title === "A fazer" ? "Colocar em produção"
+                    : title === "Possíveis devoluções" ? "Devolver"
+                    : "";
 
   return (
     <div className={`table ${showButton ? "with-button" : ""}`}>
@@ -73,30 +84,34 @@ export default function Table({ title, data, maxItems = data.length, route, onIt
             <img src={seta} alt="seta para a direita" />
           </div>
           {title === "A fazer" && (
-              <label className="select-all">
-                Selecionar tudo
-                <input
-                  type="checkbox"
-                  checked={selectAll}
-                  onChange={handleSelectAll}
-                />
-              </label>
+            <label className="select-all">
+              Selecionar tudo
+              <input
+                type="checkbox"
+                checked={selectAll}
+                onChange={handleSelectAll}
+              />
+            </label>
           )}
         </div>
+
         <div className="itens">
           {visibleItems.map((item, index) => (
             <React.Fragment key={index}>
               <div className="item-container">
-                <button 
-                  className="item" 
-                  onClick={() => handleItemClick(item)} 
+                <button
+                  className="item"
+                  onClick={() => handleItemClick(item)}
                 >
                   <div className="item-content">
                     <h2>{item.nome}</h2>
                     <p>{item.descricao}</p>
                   </div>
-                  {item.separando && <span className="status-tag">Separando</span>}
+                  {item.separando && (
+                    <span className="status-tag">Separando</span>
+                  )}
                 </button>
+
                 {(title === "A fazer" || title === "Possíveis devoluções") && (
                   <div className="checkbox-container">
                     {title === "Possíveis devoluções" ? (
@@ -121,8 +136,9 @@ export default function Table({ title, data, maxItems = data.length, route, onIt
           ))}
         </div>
       </div>
+
       {showButton && (
-        <button className="colocar-em-producao show">
+        <button className="colocar-em-producao show" onClick={handleButtonClick}>
           {buttonText}
         </button>
       )}

--- a/src/frontend/src/pages/Devolucao.jsx
+++ b/src/frontend/src/pages/Devolucao.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import Table from "../components/Table";
 import PageHeader from "../components/PageHeader";
+import PopUpFitas from "../components/PopUpFitas";
+import PopUpDevolucao from "../components/PopUpDevolucao";
 import "../styles/Devolucao.css";
 
 const dataPossivelDevolucao = [
@@ -11,7 +13,6 @@ const dataPossivelDevolucao = [
   { nome: "Fita 2", descricao: "Supporting line text lorem ipsum dolor sit amet, consectetur." },
 ];
 
-
 const dataDevolvidas = [
   { nome: "Fita 4", descricao: "Supporting line text lorem ipsum dolor sit amet, consectetur." },
   { nome: "Fita 3", descricao: "Supporting line text lorem ipsum dolor sit amet, consectetur." },
@@ -19,20 +20,53 @@ const dataDevolvidas = [
   { nome: "Fita 1", descricao: "Supporting line text lorem ipsum dolor sit amet, consectetur." },
 ];
 
-
 export default function Devolucao() {
   const location = useLocation();
-  const isSingleFita = location.pathname !== "/devolucao"
+  const isSingleFita = location.pathname !== "/devolucao";
 
+  const [selectedFita, setSelectedFita] = useState(null);
+  const [popupDevolucaoData, setPopupDevolucaoData] = useState(null);
+
+  const openPopUpFitas = (fitaData) => {
+    setSelectedFita({
+      ...fitaData,
+      estado: "Pronta"
+    });
+  };
+
+  const openPopUpDevolucao = (fitaData) => {
+    setPopupDevolucaoData({
+      ...fitaData,
+      estado: "Fazer devolução"
+    });
+  };
+
+  const closePopUpFitas = () => setSelectedFita(null);
+  const closePopUpDevolucao = () => setPopupDevolucaoData(null);
 
   return (
     <div className="Devolucao">
+      {selectedFita && <PopUpFitas data={selectedFita} closePopUp={closePopUpFitas} />}
+      {popupDevolucaoData && <PopUpDevolucao data={popupDevolucaoData} closePopUp={closePopUpDevolucao} />}
+      
       <div className="conteudo">
         <PageHeader title="Devolução" isSingleFita={isSingleFita} />
         {location.pathname === "/devolucao" ? (
           <>
-            <Table title="Possíveis devoluções" data={dataPossivelDevolucao} maxItems={4} route="/devolucao/possivel-devolucao" />
-            <Table title="Devolvidas" data={dataDevolvidas} maxItems={4} route="/devolucao/devolvidas" />
+            <Table
+              title="Possíveis devoluções"
+              data={dataPossivelDevolucao}
+              maxItems={4}
+              route="/devolucao/possivel-devolucao"
+              onItemClick={openPopUpFitas}
+              onButtonClick={openPopUpDevolucao}
+            />
+            <Table
+              title="Devolvidas"
+              data={dataDevolvidas}
+              maxItems={4}
+              route="/devolucao/devolvidas"
+            />
           </>
         ) : (
           <Outlet />
@@ -41,10 +75,3 @@ export default function Devolucao() {
     </div>
   );
 }
-
-
-
-
-
-
-

--- a/src/frontend/src/styles/PopUpFitas.css
+++ b/src/frontend/src/styles/PopUpFitas.css
@@ -31,6 +31,12 @@
     align-items: center;
 }
 
+.popup-header strong {
+    color: #7C7C7C;
+    font-weight: 700;
+    font-size: 22px;
+}
+
 .popup-header-content {
     display: flex;
     gap: 20px;
@@ -66,7 +72,8 @@
     justify-content: space-between;
     width: 100%;
     align-items: start;
-    height: 300px;
+    max-height: 300px;
+    min-height: 220px;
 }
 
 .patient-info div {
@@ -125,15 +132,13 @@
 }
 
 .exportar-btn {
-    margin-top: 20px;
-    padding: 10px 15px;
+    padding: 15px 20px;
     background-color: #666;
     color: white;
     border: none;
-    border-radius: 5px;
+    border-radius: 15px;
     cursor: pointer;
     display: block;
-    width: 100%;
 }
 
 .medicamentos-container {


### PR DESCRIPTION
## Descrição
<!-- Explique brevemente as alterações realizadas e o motivo delas. -->
esse pr adiciona o pop up de fazer devolução da fita, contando com um botão para mockar o leitor de qr codes

## Como testar?
<!-- Explique como podemos testar as alterações, incluindo passos para reproduzir e verificar as mudanças. -->
abra src/frontend rode um npm i, depois um npm start, abra na pagina de devolução, clique na fita e deve ver um pop up de fita padrão, agora feche e na tabela selecione uma fita e clique em fazer devolução deve aparecer o pop up de devolução, com botão para mocar o leitor qr

## Tipo de alteração
<!-- Marque com um X as opções que se aplicam -->
- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Atualização de documentação
- [ ] Refatoração de código
- [x] Novo componente
- [ ] Nova tela
- [x] Estilização de componente/página
- [ ] Outro (escrever)

## Checklist
<!-- Marque com um x quando o item estiver concluído -->
- [ ] Realizei testes locais e estão funcionando conforme o esperado.
- [ ] ***Este pull request está direcionado para a branch correta?***

